### PR TITLE
Add docker-buildx Makefile target that was created by kubebuilder 3.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -16,7 +17,7 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 
 # Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# the GOARCH has a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.


### PR DESCRIPTION
The current kubebuilder adds some cross-platform build support in the Makefile and Dockerfile. Incorporate those pieces into our build.